### PR TITLE
add type-hinting for reserved properties

### DIFF
--- a/picodom.d.ts
+++ b/picodom.d.ts
@@ -1,22 +1,30 @@
 export as namespace picodom
 
-export interface VNode<Props = {}> {
+export interface ReservedProps<Props = {}> extends Object {
+  key?: string
+  oncreate?: { (element: Element): any }
+  onupdate?: { (element: Element, oldProps: Props): any }
+  onremove?: { (element: Element, done: Function): any }
+  ondestroy?: { (element: Element): any }
+}
+
+export interface VNode<Props extends ReservedProps<Props> = {}> {
   type: string
   props?: Props
   children: Array<VNode | string>
 }
 
-export interface Component<Props = {}> {
+export interface Component<Props extends ReservedProps<Props> = {}> {
   (props: Props, children: Array<VNode | string>): VNode<Props>
 }
 
-export function h<Props>(
+export function h<Props extends ReservedProps<Props>>(
   type: Component<Props> | string,
   props?: Props,
   ...children: Array<VNode | string | number | null>
 ): VNode<Props>
 
-export function h<Props>(
+export function h<Props extends ReservedProps<Props>>(
   tag: Component<Props> | string,
   props?: Props,
   children?: Array<VNode | string | number | null>
@@ -32,7 +40,7 @@ declare global {
   namespace JSX {
     interface Element extends VNode<any> {}
     interface IntrinsicElements {
-      [elemName: string]: any
+      [elemName: string]: ReservedProps & { [attrName: string]: any }
     }
   }
 }

--- a/test/typings/h.test.tsx
+++ b/test/typings/h.test.tsx
@@ -1,4 +1,4 @@
-import { h, Component } from "../../"
+import { h, Component, ReservedProps } from "../../"
 
 // empty vnode
 h("div")
@@ -18,7 +18,7 @@ h("div", {}, 1, "foo", 2, "baz", 3)
 h("div", {}, "foo", h("div", {}, "bar"), "baz", "quux")
 
 // vnode with props
-interface TestProps {
+interface TestProps extends ReservedProps {
   id: string
   class: string
   style: { color: string }
@@ -62,7 +62,7 @@ let element: JSX.Element
 // element = <Wrapper />
 // element = <Wrapper id="foo">bar</Wrapper>
 element = (
-  <Wrapper {...props}>
+  <Wrapper {...props} key="foo" oncreate={ (el) => {} } onupdate={ (el, oldProps) => {} } onremove={ (el, done) => done() } ondestroy={ (el) => {} }>
     <Test />
   </Wrapper>
 )
@@ -72,3 +72,4 @@ element = (
     <span id="child2">Child 2</span>
   </Wrapper>
 )
+element = <div key="foo" oncreate={ (el) => {} } onupdate={ (el, oldProps) => {} } onremove={ (el, done) => done() } ondestroy={ (el) => {} }></div>


### PR DESCRIPTION
I attempted to add type-checking for `key` and the life-cycle attributes.

@andrewiggins can you take a look?

This works towards #36 but doesn't complete it - we still need types for for HTML/SVG attributes.

@JorgeBucaran previous PRs are [ruined](https://github.com/picodom/picodom/pull/79) - displaying unrelated comments on the page and whatnot. I have no idea how else to fix this, so I will count the PR history as lost. I'm opening new branches and new PRs cherry-picking my own commits by hand.
