### PR TITLE
update render typings

### DIFF
--- a/superfine.d.ts
+++ b/superfine.d.ts
@@ -30,12 +30,13 @@ export function h<Attributes>(
  * @param {VNode} oldNode The last virtual DOM node.
  * @param {VNode} nextNode The next virtual DOM node.
  * @param {Element?} container A DOM element where the new virtual DOM will be rendered.
+ * @returns {VNode} returns nextNode
  **/
 export function render(
   lastNode: VNode,
   nextNode: VNode,
   container: Element
-): void
+): VNode
 
 declare global {
   namespace JSX {


### PR DESCRIPTION
`render` returns the `nextNode` (type `VNode`). This change reflects that I believe.