### PR TITLE
Fixed JSX example in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Superfine has built-in support for pure components. A pure component is a functi
 ```jsx
 import { h, render } from "superfine"
 
-const ClickMe = props => (
+const ClickMe = (props, children) => (
   <a href={props.url}>
     <h1>{children}</h1>
   </a>

--- a/src/index.js
+++ b/src/index.js
@@ -328,16 +328,10 @@ var patchElement = function(
         }
       }
 
-<<<<<<< HEAD
-    for (var j in lastKeyed) {
-      if (!nextKeyed[j]) {
-        removeElement(element, lastKeyed[j][0], lastKeyed[j][1])
-=======
       for (var key in lastKeyed) {
         if (isNull(nextKeyed[key])) {
           removeElement(element, lastKeyed[key])
         }
->>>>>>> upstream/master
       }
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -242,9 +242,9 @@ var patchElement = function(
       i++
     }
 
-    for (var i in lastKeyed) {
-      if (!nextKeyed[i]) {
-        removeElement(element, lastKeyed[i][0], lastKeyed[i][1])
+    for (var j in lastKeyed) {
+      if (!nextKeyed[j]) {
+        removeElement(element, lastKeyed[j][0], lastKeyed[j][1])
       }
     }
   }


### PR DESCRIPTION
1. JSX example was missing children parameter, causing browser to throw error of undefined variable.