### PR TITLE
update typings

### DIFF
--- a/superfine.d.ts
+++ b/superfine.d.ts
@@ -6,10 +6,12 @@ export type Children = VNode | string | number | null
  * The virtual DOM representation of an Element.
  */
 export interface VNode<Props = {}> {
-  name: string
-  props?: Props
-  children: Array<VNode>
-  key: string
+  name: string,
+  props: Props,
+  children: Array<VNode>,
+  element: Element | undefined,
+  key: string | null,
+  type: number
 }
 
 /**

--- a/superfine.d.ts
+++ b/superfine.d.ts
@@ -9,7 +9,7 @@ export interface VNode<Props = {}> {
   name: string,
   props: Props,
   children: Array<VNode>,
-  element: Element | undefined,
+  element: Element | null,
   key: string | null,
   type: number
 }


### PR DESCRIPTION
This updates the type definitions with the latest changes.

One small change, I made `props` not optional on the interface because everywhere where `createVNode` is called, the props is defined. I don't know if that is what you intended semantically though.