### PR TITLE
Added computed keys based on attribute names to prevent reinsertion on prepend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.babelrc
 superfine.js*
 example*
 .gz

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ var EMPTY_ARRAY = []
 
 var map = EMPTY_ARRAY.map
 var isArray = Array.isArray
+var keys = Object.keys
 
 var merge = function(a, b) {
   var target = {}
@@ -371,7 +372,7 @@ var createVNode = function(name, props, children, element, key, type) {
     props: props,
     children: children,
     element: element,
-    key: key,
+    key: key ? key : (keys(props).length > 0 ? name + keys(props) : null),
     type: type
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -216,7 +216,9 @@ test("xlink:href", () => {
 
   patch(
     lastNode,
-    svg({ viewBox: "0 0 10 10" }, [h("use", { id: "use" })]),
+    svg({ viewBox: "0 0 10 10" }, [
+      h("use", { id: "use", "xlink:href": null })
+    ]),
     document.body
   )
 

--- a/test/test.js
+++ b/test/test.js
@@ -206,7 +206,7 @@ test("xlink:href", () => {
   let lastNode = patch(
     null,
     svg({ viewBox: "0 0 10 10" }, [
-      h("use", { id: "use", "xlink:href": "about:blank" })
+      h("use", { key: "abc", id: "use", "xlink:href": "about:blank" })
     ]),
     document.body
   )
@@ -217,7 +217,7 @@ test("xlink:href", () => {
   patch(
     lastNode,
     svg({ viewBox: "0 0 10 10" }, [
-      h("use", { id: "use", "xlink:href": null })
+      h("use", { key: "abc", id: "use" })
     ]),
     document.body
   )

--- a/test/test.js
+++ b/test/test.js
@@ -391,3 +391,28 @@ test("name as a function (JSX component syntax)", () => {
     h("div", { key: "key" }, ["bar"])
   )
 })
+
+test("reuses element on prepend", () => {
+
+  let lastNode = patch(
+    null,
+    h('div', {}, [
+      h('div', { class: 'then' }),
+    ]),
+    document.body
+  )
+
+  const div = document.querySelector("div.then")
+
+  patch(
+    lastNode,
+    h('div', {}, [
+      h('div', {}),
+      h('div', { class: 'now' }),
+    ]),
+    document.body
+  )
+
+  expect(div.classList.contains("now")).toBe(true)
+})
+


### PR DESCRIPTION
I don't want this merged &mdash; only for discussion. All of the unit tests are passing, however I'm sure this change has unintended consequences that are not covered by the tests.

Changes I'm proposing are to add a computed `key` based on the passed attributes &mdash; keys only as values are more likely to change between renders. If attributes are added/removed between renders then the element will be reinserted and can be solved by specifying a `key` manually, but I do believe that attributes are *generally* consistent between renders &ndash; only their values will differ.

Due to above change I've had to modify one of the tests where an attribute was removed (`xlink:href`). It was failing because an attribute was removed and so its key differed. Solutions to this are:

- Specify the key manually (chosen solution for the test);
- Select the `use` again (via `querySelector`) as it's a new element;
- Be explicit and add `"xlink:href": null` to the attribute list;

