### PR TITLE
Allow the passing of HTMLElement as the node name

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -82,12 +82,11 @@ var updateProperty = function(element, name, lastValue, nextValue, isSvg) {
 }
 
 var createElement = function(node, lifecycle, isSvg) {
-  var element =
-    node.type === TEXT_NODE
-      ? document.createTextNode(node.name)
-      : (isSvg = isSvg || node.name === "svg")
-        ? document.createElementNS(SVG_NS, node.name)
-        : document.createElement(node.name)
+  var element = node.element || (node.type === TEXT_NODE
+    ? document.createTextNode(node.name)
+    : (isSvg = isSvg || node.name === "svg")
+      ? document.createElementNS(SVG_NS, node.name)
+      : document.createElement(node.name))
 
   var props = node.props
   if (props.oncreate) {
@@ -437,7 +436,16 @@ export var h = function(name, props) {
     }
   }
 
+  const isElement = name instanceof HTMLElement
+
   return typeof name === "function"
     ? name(props, (props.children = children))
-    : createVNode(name, props, children, null, props.key, DEFAULT)
+    : createVNode(
+        isElement ? name.nodeName.toLowerCase() : name,
+        props,
+        children,
+        isElement ? name : null,
+        props.key,
+        DEFAULT
+      )
 }

--- a/test/test.js
+++ b/test/test.js
@@ -389,3 +389,17 @@ test("name as a function (JSX component syntax)", () => {
     h("div", { key: "key" }, ["bar"])
   )
 })
+
+test("name as a HTMLElement", () => {
+
+  const element = document.createElement("input")
+  const view = name => h(element, { name }, "bar")
+  expect(view("foo")).toEqual(h(element, { name: "foo" }, ["bar"]))
+
+  let node = patch(null, view("foo"), document.body)
+  const input = document.querySelector("input")
+  expect(input).toEqual(element)
+  patch(node, view("bar"), document.body)
+  expect(input).toEqual(element)
+
+})


### PR DESCRIPTION
I'm experimenting with an approach where you can pass the `HTMLElement` to be used for the tree itself, rather than letting `superfine` create the element itself to then depend on the `oncreate` callback to gather references.

For instance:

```javascript
const todoInput = document.createElement('input');

h('div', {}, [
    h(todoInput, { type: 'text', onchange: render }),
    h('div', {}, `Valid: ${todoInput.validity.valid}`)
])
```

Would be super useful as I'd be able to use `todoInput` as it is without any `null` checking.

The alternative being to let `superfine` create a random `HTMLElement` itself and use `oncreate` to re-render the tree &ndash; which causes three *problems*: `null` checking to ensure we have `todoInput`, multiple passes of DOM reconciliation (`oncreate` × node count), and a little boilerplate for the `oncreate` itself:

```javascript
h('div', {}, [
    h('input', { type: 'text', oncreate: node => (todoInput = node, render()) }),
    todoInput.validity.valid && h('div', {}, `Valid: ${todoInput.validity.valid}`)
])
```