### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ export const Camera = onerror =>
 {
   "plugins": [
     [
-      "transform-react-jsx",
+      "@babel/plugin-transform-react-jsx",
       {
         "pragma": "h"
       }


### PR DESCRIPTION
Fix babel plugin name from "transform-react-jsx" to "@babel/plugin-transform-react-jsx".

("transform-react-jsx" was giving me weird errors until I changed it)