### PR TITLE
change patch semantics to append mode

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -262,13 +262,17 @@ var recycleNode = function(node) {
 export var patch = function(node, vdom) {
   return (
     ((node = patchNode(
-      node.parentNode,
       node,
-      node.vdom || recycleNode(node),
+      node.children[0],
+      node.vdom,
       vdom
     )).vdom = vdom),
     node
   )
+}
+
+export var recycle = function(container) {
+  return recycleNode(container.children[0])
 }
 
 export var h = function(name, props) {


### PR DESCRIPTION
This is one possible fixe for #172. We change patch semantics to use append to container like in v6

I assume this will break SSR as recycling might need more work. But without tests added to V7 branch, I can't tell this certainly.

I will try to create another PR which will play with replace container mode.